### PR TITLE
Dev guide links

### DIFF
--- a/English/Android/current-release/android-dev-guide.md
+++ b/English/Android/current-release/android-dev-guide.md
@@ -70,7 +70,7 @@ Including Google Play Services with your project will allow Vungle to provide a 
 
 http://developer.android.com/google/play-services/setup.html#Setup
 
-3) In your app, ensure that the device has a sufficiently up-to-date version of Google Play Services:
+2) In your app, ensure that the device has a sufficiently up-to-date version of Google Play Services:
 
 http://developer.android.com/google/play-services/setup.html#ensure
 

--- a/English/Android/past-releases/3.0.x/android-advanced-settings.md
+++ b/English/Android/past-releases/3.0.x/android-advanced-settings.md
@@ -2,7 +2,7 @@
 
 ## Please note:
 
-This reference covers the more advanced settings and customizeable aspects of Vungle ads. If you're just getting started, you'll want to check out this [guide](https://github.com/Vungle/vungle-resources/blob/master/English/Android/3.0.x/android-dev-guide.md). 
+This reference covers the more advanced settings and customizeable aspects of Vungle ads. If you're just getting started, you'll want to check out this [guide](https://github.com/Vungle/vungle-resources/blob/master/English/Android/past-releases/3.0.x/android-dev-guide.md). 
 
 ## Advanced Configuration 
 

--- a/English/Android/past-releases/3.0.x/android-advanced-settings.md
+++ b/English/Android/past-releases/3.0.x/android-advanced-settings.md
@@ -2,7 +2,7 @@
 
 ## Please note:
 
-This reference covers the more advanced settings and customizeable aspects of Vungle ads. If you're just getting started, you'll want to check out this [guide](https://github.com/Vungle/vungle-resources/blob/master/English/Android/past-releases/3.0.x/android-dev-guide.md). 
+This reference covers the more advanced settings and customizeable aspects of Vungle ads. If you're just getting started, you'll want to check out this [guide](android-dev-guide.md). 
 
 ## Advanced Configuration 
 

--- a/English/Android/past-releases/3.0.x/android-dev-guide.md
+++ b/English/Android/past-releases/3.0.x/android-dev-guide.md
@@ -152,4 +152,4 @@ That's it! Quick start guide complete. Stick around if you'd like to check out s
 <a name="advancedStartupConfig"></a>
 ## Advanced Settings
 
-Check out our [advanced settings](https://github.com/Vungle/vungle-resources/blob/master/English/Android/past-releases/3.0.x/android-advanced-settings.md) for instructions on ad customization, debugging, and event callbacks!
+Check out our [advanced settings](android-advanced-settings.md) for instructions on ad customization, debugging, and event callbacks!

--- a/English/Android/past-releases/3.0.x/android-dev-guide.md
+++ b/English/Android/past-releases/3.0.x/android-dev-guide.md
@@ -152,4 +152,4 @@ That's it! Quick start guide complete. Stick around if you'd like to check out s
 <a name="advancedStartupConfig"></a>
 ## Advanced Settings
 
-Check out our [advanced settings](https://github.com/Vungle/vungle-resources/blob/master/English/Android/3.0.x/android-advanced-settings.md) for instructions on ad customization, debugging, and event callbacks!
+Check out our [advanced settings](https://github.com/Vungle/vungle-resources/blob/master/English/Android/past-releases/3.0.x/android-advanced-settings.md) for instructions on ad customization, debugging, and event callbacks!

--- a/English/Android/past-releases/3.1.x/android-advanced-settings.md
+++ b/English/Android/past-releases/3.1.x/android-advanced-settings.md
@@ -2,7 +2,7 @@
 
 ## Please note:
 
-This reference covers the more advanced settings and customizeable aspects of Vungle ads. If you're just getting started, you'll want to check out this [guide](https://github.com/Vungle/vungle-resources/blob/master/English/Android/past-releases/3.1.x/android-dev-guide.md). 
+This reference covers the more advanced settings and customizeable aspects of Vungle ads. If you're just getting started, you'll want to check out this [guide](android-dev-guide.md). 
 
 ## Advanced Configuration 
 

--- a/English/Android/past-releases/3.1.x/android-advanced-settings.md
+++ b/English/Android/past-releases/3.1.x/android-advanced-settings.md
@@ -2,7 +2,7 @@
 
 ## Please note:
 
-This reference covers the more advanced settings and customizeable aspects of Vungle ads. If you're just getting started, you'll want to check out this [guide](https://github.com/Vungle/vungle-resources/blob/master/English/Android/3.1.x/android-dev-guide.md). 
+This reference covers the more advanced settings and customizeable aspects of Vungle ads. If you're just getting started, you'll want to check out this [guide](https://github.com/Vungle/vungle-resources/blob/master/English/Android/past-releases/3.1.x/android-dev-guide.md). 
 
 ## Advanced Configuration 
 

--- a/English/Android/past-releases/3.1.x/android-dev-guide.md
+++ b/English/Android/past-releases/3.1.x/android-dev-guide.md
@@ -165,4 +165,4 @@ That's it! Quick start guide complete. Stick around if you'd like to check out s
 <a name="advancedStartupConfig"></a>
 ## Advanced Settings
 
-Check out our [advanced settings](https://github.com/Vungle/vungle-resources/blob/master/English/Android/past-releases/3.1.x/android-advanced-settings.md) for instructions on ad customization, debugging, and event callbacks!
+Check out our [advanced settings](android-advanced-settings.md) for instructions on ad customization, debugging, and event callbacks!

--- a/English/Android/past-releases/3.1.x/android-dev-guide.md
+++ b/English/Android/past-releases/3.1.x/android-dev-guide.md
@@ -165,4 +165,4 @@ That's it! Quick start guide complete. Stick around if you'd like to check out s
 <a name="advancedStartupConfig"></a>
 ## Advanced Settings
 
-Check out our [advanced settings](https://github.com/Vungle/vungle-resources/blob/master/English/Android/3.1.x/android-advanced-settings.md) for instructions on ad customization, debugging, and event callbacks!
+Check out our [advanced settings](https://github.com/Vungle/vungle-resources/blob/master/English/Android/past-releases/3.1.x/android-advanced-settings.md) for instructions on ad customization, debugging, and event callbacks!

--- a/English/Android/past-releases/3.2.x/android-advanced-settings.md
+++ b/English/Android/past-releases/3.2.x/android-advanced-settings.md
@@ -2,7 +2,7 @@
 
 ## Please note:
 
-This reference covers the more advanced settings and customizeable aspects of Vungle ads. If you're just getting started, you'll want to check out this [guide](https://github.com/Vungle/vungle-resources/blob/master/English/Android/3.2.x/android-dev-guide.md). 
+This reference covers the more advanced settings and customizeable aspects of Vungle ads. If you're just getting started, you'll want to check out this [guide](https://github.com/Vungle/vungle-resources/blob/master/English/Android/past-releases/3.2.x/android-dev-guide.md). 
 
 ## Advanced Configuration 
 

--- a/English/Android/past-releases/3.2.x/android-advanced-settings.md
+++ b/English/Android/past-releases/3.2.x/android-advanced-settings.md
@@ -2,7 +2,7 @@
 
 ## Please note:
 
-This reference covers the more advanced settings and customizeable aspects of Vungle ads. If you're just getting started, you'll want to check out this [guide](https://github.com/Vungle/vungle-resources/blob/master/English/Android/past-releases/3.2.x/android-dev-guide.md). 
+This reference covers the more advanced settings and customizeable aspects of Vungle ads. If you're just getting started, you'll want to check out this [guide](android-dev-guide.md). 
 
 ## Advanced Configuration 
 

--- a/English/Android/past-releases/3.2.x/android-dev-guide.md
+++ b/English/Android/past-releases/3.2.x/android-dev-guide.md
@@ -167,4 +167,4 @@ That's it! Quick start guide complete. Stick around if you'd like to check out s
 <a name="advancedStartupConfig"></a>
 ## Advanced Settings
 
-Check out our [advanced settings](https://github.com/Vungle/vungle-resources/blob/master/English/Android/3.2.x/android-advanced-settings.md) for instructions on ad customization, debugging, and event callbacks!
+Check out our [advanced settings](https://github.com/Vungle/vungle-resources/blob/master/English/Android/past-releases/3.2.x/android-advanced-settings.md) for instructions on ad customization, debugging, and event callbacks!

--- a/English/Android/past-releases/3.2.x/android-dev-guide.md
+++ b/English/Android/past-releases/3.2.x/android-dev-guide.md
@@ -167,4 +167,4 @@ That's it! Quick start guide complete. Stick around if you'd like to check out s
 <a name="advancedStartupConfig"></a>
 ## Advanced Settings
 
-Check out our [advanced settings](https://github.com/Vungle/vungle-resources/blob/master/English/Android/past-releases/3.2.x/android-advanced-settings.md) for instructions on ad customization, debugging, and event callbacks!
+Check out our [advanced settings](android-advanced-settings.md) for instructions on ad customization, debugging, and event callbacks!


### PR DESCRIPTION
Links were broken when folders were moved. This updates all links to go back and fourth between advanced and normal dev guides. Also there was a numbering issue fixed here that was caused by updating the documentation. 